### PR TITLE
Install Physine library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 *.swp
-build/*
+build/
 extern/*
 .DS_Store

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(Samples VERSION 1.0 LANGUAGES CXX)
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED True)
+
+add_subdirectory(src)

--- a/examples/src/CMakeLists.txt
+++ b/examples/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+project(BallsSample VERSION 1.0 LANGUAGES CXX)
+
+find_package(physine 1.0 REQUIRED)
+include_directories(${physine_INCLUDE_DIRS})
+
+add_executable(FallingBalls FallingBalls.cpp)
+target_link_libraries(FallingBalls PhysineCore)

--- a/examples/src/FallingBalls.cpp
+++ b/examples/src/FallingBalls.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <random>
+
+#include <Physine/common.h>
+#include <Physine/world.h>
+#include <Physine/drawable.h>
+#include <Physine/collider.h>
+#include <Physine/color.h>
+#include <Physine/object_builder.h>
+
+int main(int argc, const char** argv) {
+    World world(1000, 1000);
+
+    world.add_event_listener(EventType::Closed, [&world](Event e) { world.close(); });
+
+    Object* rect1 = ObjectBuilder("Rect1")
+        .drawable(new RectangleShape())
+        .color(Color::RED)
+        .collider<BoxCollider>()
+        .position(Vector2f{500, 10})
+        .scale(Vector2f{1000, 20})
+        .mass(10000)
+        .gravity(false)
+        .kinetic(false)
+        .build();
+
+    Object* rect2 = ObjectBuilder::duplicate("Rect2", rect1)
+        .position(Vector2f{500, 990})
+        .build();
+
+    Object* rect3 = ObjectBuilder::duplicate("Rect3", rect1)
+        .position(Vector2f{10, 500})
+        .scale(Vector2f{20, 1000})
+        .build();
+
+    Object* rect4 = ObjectBuilder::duplicate("Rect4", rect3)
+        .position(Vector2f{990, 500})
+        .build();
+
+    world.add_object(rect1);
+    world.add_object(rect2);
+    world.add_object(rect3);
+    world.add_object(rect4);
+
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> dist500(0, 500);
+    std::uniform_int_distribution<std::mt19937::result_type> dist50(10, 50);
+
+    for (int i = 0; i < 100; i += 10) {
+        Object* obj = ObjectBuilder("circle" + std::to_string(i))
+            .drawable(new CircleShape())
+            .color(Color::random_color())
+            .position(Vector2f{i*10., i*10.})
+            .scale(Vector2f{double(dist50(rng)), double(dist50(rng))})
+            .velocity(Vector2f{double(dist500(rng)), double(dist500(rng))})
+            .collider<CircleCollider>()
+            .gravity(true)
+            .build();
+        obj->mass = obj->transform->scale.x();
+        world.add_object(obj);
+    }
+
+    world.mainloop();
+
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,16 +1,13 @@
 cmake_minimum_required(VERSION 3.12)
 project (Physine VERSION 1.0 LANGUAGES CXX)
 
-add_library(PhysineCore collider.cpp world.cpp circle_shape.cpp text_drawable.cpp image_drawable.cpp
+set(version 1.0)
+
+add_library(PhysineCore STATIC collider.cpp world.cpp circle_shape.cpp image_drawable.cpp
     rectangle_shape.cpp graphics.cpp collision_solver.cpp debug.cpp color.cpp event_manager.cpp
     ph_math.cpp)
 
 target_compile_options(PhysineCore PRIVATE -Wall -Wextra -Wpedantic -Wno-c99-extensions)
-
-add_executable(${PROJECT_NAME} main.cpp)
-add_executable(Test test.cpp)
-add_executable(AirResistance air_resistance_sample.cpp)
-add_executable(Rotation rotation_test.cpp)
 
 find_package(SFML 2.5 COMPONENTS system window graphics network audio REQUIRED)
 
@@ -19,15 +16,30 @@ if (SFML_FOUND)
     target_link_libraries(PhysineCore sfml-network sfml-audio sfml-graphics sfml-window sfml-system)
 endif()
 
-target_link_libraries(${PROJECT_NAME} PUBLIC PhysineCore)
-target_link_libraries(Test PUBLIC PhysineCore)
-target_link_libraries(AirResistance PUBLIC PhysineCore)
-target_link_libraries(Rotation PUBLIC PhysineCore)
-
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
+target_include_directories(PhysineCore PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../extern>
-)
+install(FILES collider.h color.h event.h keyboard.h rect.h callback_list.h collision.h common.h world.h
+        circle.h collision_points.h constants.h event_manager.h object.h timer.h object_builder.h
+        transform.h clock.h collision_solver.h debug.h graphics.h utils.h drawable.h ph_math.h vector.h
+        DESTINATION include/physine-${version})
+install(TARGETS PhysineCore
+    DESTINATION lib/physine-${version}
+    EXPORT physine-targets)
+install(EXPORT physine-targets
+    DESTINATION lib/physine-${version})
+
+configure_file(
+    ${Physine_SOURCE_DIR}/pkg/physine-config.cmake.in
+    ${Physine_BINARY_DIR}/pkg/physine-config.cmake @ONLY
+    )
+
+configure_file(
+    ${Physine_SOURCE_DIR}/physine-config-version.cmake.in
+    ${Physine_BINARY_DIR}/physine-config-version.cmake @ONLY
+    )
+
+install(FILES ${Physine_BINARY_DIR}/pkg/physine-config.cmake
+    ${Physine_BINARY_DIR}/physine-config-version.cmake
+    DESTINATION lib/physine-${version})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(PhysineCore PUBLIC
 install(FILES collider.h color.h event.h keyboard.h rect.h callback_list.h collision.h common.h world.h
         circle.h collision_points.h constants.h event_manager.h object.h timer.h object_builder.h
         transform.h clock.h collision_solver.h debug.h graphics.h utils.h drawable.h ph_math.h vector.h
-        DESTINATION include/physine-${version})
+        DESTINATION include/physine-${version}/Physine)
 install(TARGETS PhysineCore
     DESTINATION lib/physine-${version}
     EXPORT physine-targets)

--- a/src/physine-config-version.cmake.in
+++ b/src/physine-config-version.cmake.in
@@ -1,0 +1,7 @@
+set(PACKAGE_VERSION "@version@")
+if (NOT "${PACKAGE_FIND_VERSION}" VERSION_GREATER "@version@")
+    set(PACKAGE_VERSION_COMPATIBLE 1)
+    if ("${PACKAGE_FIND_VERSION}" VERSION_EQUAL "@version@")
+        set(PACKAGE_VERSION_EXACT 1)
+    endif()
+endif()

--- a/src/pkg/physine-config.cmake.in
+++ b/src/pkg/physine-config.cmake.in
@@ -1,0 +1,6 @@
+get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
+
+include("${_prefix}/lib/physine-@version@/physine-targets.cmake")
+
+set(physine_INCLUDE_DIRS "${_prefix}/include/physine-@version@")


### PR DESCRIPTION
Installs the Physine library in the system and copies the configuration files to the appropriate cmake directories. Other CMake projects can use the library by using **find_package(Physine)**. I also included an example program that uses the library.